### PR TITLE
Add RSS feed for Revisions Digest

### DIFF
--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -374,7 +374,8 @@ function render_feed() : void {
 	<?php foreach ( $changes as $change ) : ?>
 	<item>
 		<title><?php echo esc_html( get_the_title( $change['post_id'] ) ); ?></title>
-		<link><?php echo esc_url( get_edit_post_link( $change['post_id'], 'raw' ) ); ?></link>
+		<?php $link = get_edit_post_link( $change['post_id'], 'raw' ) ?: get_permalink( $change['post_id'] ); ?>
+		<link><?php echo esc_url( $link ); ?></link>
 		<guid isPermaLink="false"><?php echo esc_html( $change['post_id'] . '-' . $change['latest']->ID ); ?></guid>
 		<pubDate><?php echo esc_html( mysql2date( 'r', $change['latest']->post_modified_gmt, false ) ); ?></pubDate>
 		<?php


### PR DESCRIPTION
Closes https://github.com/adamsilverstein/revisions-digest/issues/4

## Summary
- Adds an optional RSS feed that displays recent content changes from the revisions digest
- Feed is disabled by default and can be enabled via Settings → Reading
- Requires authentication (returns 403 Forbidden for logged-out users)
- Feed URL: `/feed/revisions-digest/`

## Test plan
- [ ] Enable the feed in Settings → Reading
- [ ] Verify feed URL appears in settings when enabled
- [ ] Access `/feed/revisions-digest/` while logged out - should get 403
- [ ] Access `/feed/revisions-digest/` while logged in - should get valid RSS
- [ ] Make some page edits and verify they appear in feed
- [ ] Disable the feed and verify 404 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RSS feed support for Revisions Digest, configurable in Reading settings
  * Feed URL is shown in settings when the feed is enabled
  * RSS includes post revision changes with rendered diff content
  * Feed access requires user login authentication

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->