### PR TITLE
Add GitHub Actions workflow to deploy plugin to WordPress.org

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,28 @@
+# Directories
+.claude/
+.conductor/
+.cursor/
+.github/
+.husky/
+bin/
+examples/
+node_modules/
+tests/
+vendor/
+
+# Files
+.DS_Store
+.editorconfig
+.eslintrc.json
+.gitignore
+.stylelintrc.json
+.travis.yml
+CLAUDE.md
+composer.json
+composer.lock
+package.json
+package-lock.json
+phpcs.xml.dist
+phpstan-bootstrap.php
+phpstan.neon
+phpunit.xml.dist

--- a/.github/workflows/deploy-to-wordpress-org.yml
+++ b/.github/workflows/deploy-to-wordpress-org.yml
@@ -1,0 +1,23 @@
+name: Deploy to WordPress.org
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to WordPress.org
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: revisions-digest


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/deploy-to-wordpress-org.yml`) using `10up/action-wordpress-plugin-deploy` that triggers on release publication
- Adds `.distignore` to exclude dev-only files (tests, node_modules, CI config, etc.) from the deployed package

## Setup required

Before creating a release, configure these repository secrets:
- `SVN_USERNAME` — WordPress.org SVN username
- `SVN_PASSWORD` — WordPress.org SVN password

Closes #20

## Test plan

- [ ] Verify `.distignore` excludes all dev-only files and includes all runtime files
- [ ] Add `SVN_USERNAME` and `SVN_PASSWORD` secrets to the repository
- [ ] Create a GitHub release and confirm the workflow triggers and deploys successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added distribution packaging configuration to exclude unnecessary files and directories from releases
  * Enabled automated deployment to WordPress.org upon release publication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->