### PR TITLE
Add signed unsubscribe link to digest emails

### DIFF
--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -641,13 +641,16 @@ function get_unsubscribe_url( string $subscription_id ): string {
 add_action(
 	'template_redirect',
 	function (): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Unsubscribe links use HMAC token verification, not nonces.
 		if ( empty( $_GET['revisions_digest_unsubscribe'] ) || empty( $_GET['token'] ) ) {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$subscription_id = sanitize_text_field( wp_unslash( $_GET['revisions_digest_unsubscribe'] ) );
-		$token           = sanitize_text_field( wp_unslash( $_GET['token'] ) );
-		$expected_token  = get_unsubscribe_token( $subscription_id );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$token          = sanitize_text_field( wp_unslash( $_GET['token'] ) );
+		$expected_token = get_unsubscribe_token( $subscription_id );
 
 		if ( ! hash_equals( $expected_token, $token ) ) {
 			wp_die(
@@ -1028,11 +1031,11 @@ function send_digest_email( string $subscription_id ): bool {
 		return false;
 	}
 
-	$timeframe     = get_timeframe_for_frequency( $subscription['frequency'] );
-	$changes       = get_digest_changes_for_timeframe( $timeframe );
-	$subject       = get_email_subject( count( $changes ) );
-	$unsubscribe   = get_unsubscribe_url( $subscription_id );
-	$content       = get_email_content( $changes, $unsubscribe );
+	$timeframe   = get_timeframe_for_frequency( $subscription['frequency'] );
+	$changes     = get_digest_changes_for_timeframe( $timeframe );
+	$subject     = get_email_subject( count( $changes ) );
+	$unsubscribe = get_unsubscribe_url( $subscription_id );
+	$content     = get_email_content( $changes, $unsubscribe );
 
 	$headers = [
 		'Content-Type: text/html; charset=UTF-8',


### PR DESCRIPTION
## Summary

- Adds `get_unsubscribe_token()` and `get_unsubscribe_url()` functions using HMAC-SHA256 signed with `wp_salt('nonce')`
- Handles unsubscribe requests via `template_redirect` with constant-time token verification (`hash_equals`)
- Adds `List-Unsubscribe` and `List-Unsubscribe-Post` email headers for native email client support
- Adds a visible "Unsubscribe" link in the email footer

## Test plan

- [ ] Subscribe to a digest, receive an email, verify unsubscribe link is present in footer
- [ ] Click unsubscribe link, confirm subscription is removed and success message shown
- [ ] Tamper with the token in the URL, confirm access is denied with 403
- [ ] Try an already-deleted subscription ID, confirm 404 error
- [ ] Check email headers contain `List-Unsubscribe`

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Digest emails now include per-subscription secure unsubscribe links in the footer, letting recipients opt out directly.
  * Emails include RFC-style one-click unsubscribe headers to improve deliverability and make unsubscribe actions easier from mail clients.
  * The site now processes unsubscribe requests from those links, ensuring links are validated and subscriptions are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->