### PR TITLE
Add pagination to the REST API digest endpoint

### DIFF
--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -95,10 +95,26 @@ class REST_Controller extends WP_REST_Controller {
 		$digest      = new Digest( $period, $group_by );
 		$all_changes = $digest->get_changes();
 
-		$total   = count( $all_changes );
+		// Flatten grouped results into a flat list for pagination.
+		// Non-default group_by modes return associative arrays of arrays.
+		$flat_changes = [];
+		foreach ( $all_changes as $key => $value ) {
+			if ( isset( $value['post_id'] ) ) {
+				// Already a flat change item.
+				$flat_changes[] = $value;
+			} else {
+				// Grouped bucket — merge individual changes, tagging with group key.
+				foreach ( $value as $change ) {
+					$change['group'] = $key;
+					$flat_changes[]  = $change;
+				}
+			}
+		}
+
+		$total   = count( $flat_changes );
 		$pages   = (int) ceil( $total / $per_page );
 		$offset  = ( $page - 1 ) * $per_page;
-		$changes = array_slice( $all_changes, $offset, $per_page );
+		$changes = array_slice( $flat_changes, $offset, $per_page );
 
 		$response_data = [];
 
@@ -120,7 +136,7 @@ class REST_Controller extends WP_REST_Controller {
 				)
 			);
 
-			$response_data[] = [
+			$item = [
 				'post_id'          => $change['post_id'],
 				'post_title'       => get_the_title( $change['post_id'] ),
 				'post_url'         => get_permalink( $change['post_id'] ),
@@ -130,6 +146,12 @@ class REST_Controller extends WP_REST_Controller {
 				'excerpt_rendered' => $change['excerpt_rendered'] ?? '',
 				'authors'          => array_values( $authors ),
 			];
+
+			if ( isset( $change['group'] ) ) {
+				$item['group'] = $change['group'];
+			}
+
+			$response_data[] = $item;
 		}
 
 		$response = new WP_REST_Response(


### PR DESCRIPTION
## Summary

- Adds `page` (default: 1) and `per_page` (default: 10, max: 100) parameters to the `/revisions-digest/v1/digest` endpoint
- Returns `X-WP-Total` and `X-WP-TotalPages` response headers following WP REST API conventions
- Slices the full results array server-side to return only the requested page

## Test plan

- [ ] `GET /revisions-digest/v1/digest` returns default 10 items with correct headers
- [ ] `GET /revisions-digest/v1/digest?per_page=2&page=1` returns first 2 items
- [ ] `GET /revisions-digest/v1/digest?per_page=2&page=2` returns next 2 items
- [ ] Verify `X-WP-Total` and `X-WP-TotalPages` headers are accurate
- [ ] `per_page=0` or `per_page=101` returns validation error

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST API endpoints now support pagination via page and per_page query parameters.
  * Responses return only the requested page of items while preserving response shape and include a conditional group field when applicable.
  * Responses include X-WP-Total and X-WP-TotalPages headers indicating total items and total pages.
  * Default page size is 10; per_page can be increased up to 100.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->