### PR TITLE
Add Send Test Email button for digest subscriptions

### DIFF
--- a/assets/js/subscriptions.js
+++ b/assets/js/subscriptions.js
@@ -103,11 +103,17 @@
 							escapeHtml(data.data.id) +
 							'">' +
 							escapeHtml(i18n.deleteLabel) +
+							'</a> | ' +
+							'<a href="#" class="test-subscription" data-id="' +
+							escapeHtml(data.data.id) +
+							'">' +
+							escapeHtml(i18n.sendTest || 'Send Test') +
 							'</a>' +
 							'</span>';
 						list.appendChild(li);
 						bindDeleteHandlers();
 						bindEditHandlers();
+						bindTestHandlers();
 					} else {
 						showMessage(addForm, data.data.message, 'error');
 					}
@@ -262,7 +268,51 @@
 		});
 	}
 
+	// Send test email handlers.
+	function bindTestHandlers() {
+		const testLinks = document.querySelectorAll('.test-subscription');
+		testLinks.forEach(function (link) {
+			link.onclick = function (e) {
+				e.preventDefault();
+				const id = this.getAttribute('data-id');
+				const btn = this;
+				btn.textContent = i18n.sending || 'Sending...';
+
+				const formData = new FormData();
+				formData.append('action', 'revisions_digest_send_test_email');
+				formData.append('nonce', nonce);
+				formData.append('id', id);
+
+				fetch(ajaxurl, {
+					method: 'POST',
+					body: formData,
+				})
+					.then(function (response) {
+						return response.json();
+					})
+					.then(function (data) {
+						btn.textContent = i18n.sendTest || 'Send Test';
+						if (data.success) {
+							btn.textContent = i18n.sent || 'Sent!';
+							setTimeout(function () {
+								btn.textContent = i18n.sendTest || 'Send Test';
+							}, 3000);
+						} else {
+							// eslint-disable-next-line no-alert
+							alert(data.data.message);
+						}
+					})
+					.catch(function () {
+						btn.textContent = i18n.sendTest || 'Send Test';
+						// eslint-disable-next-line no-alert
+						alert(i18n.errorOccurred);
+					});
+			};
+		});
+	}
+
 	// Initial binding.
 	bindDeleteHandlers();
 	bindEditHandlers();
+	bindTestHandlers();
 })();

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -1160,7 +1160,20 @@ add_action(
 		// Verify subscription ownership.
 		verify_subscription_ownership( $id );
 
-		$sent = send_digest_email( $id );
+		$subscription = get_subscription( $id );
+		if ( ! $subscription ) {
+			wp_send_json_error( [ 'message' => __( 'Subscription not found.', 'revisions-digest' ) ] );
+		}
+
+		// Send the email without updating last_sent so scheduled digests are not affected.
+		$timeframe = get_timeframe_for_frequency( $subscription['frequency'] );
+		$changes   = get_digest_changes_for_timeframe( $timeframe );
+		$subject   = get_email_subject( count( $changes ) );
+		$unsub_url = get_unsubscribe_url( $id );
+		$content   = get_email_content( $changes, $unsub_url );
+		$headers   = [ 'Content-Type: text/html; charset=UTF-8' ];
+
+		$sent = wp_mail( $subscription['email'], $subject, $content, $headers );
 
 		if ( $sent ) {
 			wp_send_json_success( [ 'message' => __( 'Test email sent successfully.', 'revisions-digest' ) ] );
@@ -1169,6 +1182,7 @@ add_action(
 		wp_send_json_error( [ 'message' => __( 'Failed to send test email.', 'revisions-digest' ) ] );
 	}
 );
+
 /**
  * Register RSS feed settings in Settings → Reading.
  */

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -147,6 +147,9 @@ function enqueue_dashboard_assets( string $hook_suffix ): void {
 					'deleteLabel'          => __( 'Delete', 'revisions-digest' ),
 					'errorOccurred'        => __( 'An error occurred.', 'revisions-digest' ),
 					'confirmDelete'        => __( 'Are you sure you want to delete this subscription?', 'revisions-digest' ),
+					'sendTest'             => __( 'Send Test', 'revisions-digest' ),
+					'sending'              => __( 'Sending...', 'revisions-digest' ),
+					'sent'                 => __( 'Sent!', 'revisions-digest' ),
 				],
 			]
 		);

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -345,6 +345,8 @@ function render_subscription_list( array $subscriptions, string $nonce ): void {
 						<a href="#" class="edit-subscription" data-id="<?php echo esc_attr( $id ); ?>" data-email="<?php echo esc_attr( $subscription['email'] ); ?>" data-frequency="<?php echo esc_attr( $subscription['frequency'] ); ?>"><?php esc_html_e( 'Edit', 'revisions-digest' ); ?></a>
 						|
 						<a href="#" class="delete-subscription" data-id="<?php echo esc_attr( $id ); ?>"><?php esc_html_e( 'Delete', 'revisions-digest' ); ?></a>
+						|
+						<a href="#" class="test-subscription" data-id="<?php echo esc_attr( $id ); ?>"><?php esc_html_e( 'Send Test', 'revisions-digest' ); ?></a>
 					</span>
 				</li>
 			<?php endforeach; ?>
@@ -1141,6 +1143,32 @@ add_action(
 	}
 );
 
+/**
+ * AJAX handler for sending a test email.
+ */
+add_action(
+	'wp_ajax_revisions_digest_send_test_email',
+	function (): void {
+		check_ajax_referer( 'revisions_digest_subscription', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'revisions-digest' ) ] );
+		}
+
+		$id = isset( $_POST['id'] ) ? sanitize_text_field( wp_unslash( $_POST['id'] ) ) : '';
+
+		// Verify subscription ownership.
+		verify_subscription_ownership( $id );
+
+		$sent = send_digest_email( $id );
+
+		if ( $sent ) {
+			wp_send_json_success( [ 'message' => __( 'Test email sent successfully.', 'revisions-digest' ) ] );
+		}
+
+		wp_send_json_error( [ 'message' => __( 'Failed to send test email.', 'revisions-digest' ) ] );
+	}
+);
 /**
  * Register RSS feed settings in Settings → Reading.
  */


### PR DESCRIPTION
## Summary

- Adds `wp_ajax_revisions_digest_send_test_email` AJAX handler that calls `send_digest_email()` immediately
- Adds a "Send Test" link next to Edit/Delete in the subscription list
- Button shows inline feedback: "Sending..." while in progress, "Sent!" on success for 3 seconds

## Test plan

- [ ] Add a subscription, verify "Send Test" link appears
- [ ] Click "Send Test", verify button shows "Sending..." then "Sent!"
- [ ] Check inbox for the test digest email
- [ ] Verify non-owners cannot send test emails for other users' subscriptions

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Send Test" action to each email subscription in the management dashboard.
  * Sends a real test email (includes unsubscribe link) for the subscription’s frequency window.
  * Provides immediate UI feedback: "Sending…", "Sent!", and error alerts on failure.
  * Test requests are validated for security before sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->