### PR TITLE
Cache digest results with versioned invalidation

### DIFF
--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -36,6 +36,13 @@ class Digest {
 	const GROUP_BY_TAXONOMY = 'taxonomy';
 
 	/**
+	 * Option name holding the cache version. Bumping it invalidates every
+	 * cached digest at once, which is reliable even with an external object
+	 * cache (where enumerating transient keys is not).
+	 */
+	const CACHE_VERSION_OPTION = 'revisions_digest_cache_version';
+
+	/**
 	 * Default time period
 	 *
 	 * @var string
@@ -88,6 +95,89 @@ class Digest {
 	 * }
 	 */
 	public function get_changes(): array {
+		// Cached payloads contain Text_Diff (and Text_Diff_Op_*) objects. Their
+		// classes must be loaded before get_transient() unserializes them,
+		// otherwise a cache hit yields __PHP_Incomplete_Class instances and
+		// get_grouped_changes() fatals when reading the diff.
+		if ( ! class_exists( 'Text_Diff', false ) ) {
+			require_once ABSPATH . WPINC . '/wp-diff.php';
+		}
+
+		$cache_key = $this->get_cache_key();
+
+		/**
+		 * Filters how long, in seconds, a computed digest is cached.
+		 *
+		 * Return zero or a negative value to disable caching entirely.
+		 *
+		 * @param int    $ttl      Cache lifetime in seconds. Default one hour.
+		 * @param string $period   The digest period.
+		 * @param string $group_by The grouping method.
+		 */
+		$ttl = (int) apply_filters( 'revisions_digest_cache_ttl', HOUR_IN_SECONDS, $this->period, $this->group_by );
+
+		if ( $ttl > 0 ) {
+			$cached = get_transient( $cache_key );
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
+		}
+
+		$changes = $this->compute_changes();
+
+		if ( $ttl > 0 ) {
+			set_transient( $cache_key, $changes, $ttl );
+		}
+
+		return $changes;
+	}
+
+	/**
+	 * Build the transient cache key for this digest's parameters.
+	 *
+	 * The key incorporates the cache version so that {@see Digest::flush_cache()}
+	 * invalidates every cached digest atomically.
+	 *
+	 * @return string Cache key.
+	 */
+	public function get_cache_key(): string {
+		$parts = [
+			'v'  => self::get_cache_version(),
+			'p'  => $this->period,
+			'g'  => $this->group_by,
+			't'  => $this->custom_timeframe,
+			'pt' => get_option( 'revisions_digest_post_types', [ 'page' ] ),
+		];
+
+		return 'revisions_digest_' . md5( (string) wp_json_encode( $parts ) );
+	}
+
+	/**
+	 * Get the current cache version.
+	 *
+	 * @return int Cache version.
+	 */
+	private static function get_cache_version(): int {
+		return (int) get_option( self::CACHE_VERSION_OPTION, 1 );
+	}
+
+	/**
+	 * Invalidate all cached digests by bumping the cache version.
+	 *
+	 * Hooked to post mutation actions so digests refresh when content changes.
+	 *
+	 * @return void
+	 */
+	public static function flush_cache(): void {
+		update_option( self::CACHE_VERSION_OPTION, self::get_cache_version() + 1 );
+	}
+
+	/**
+	 * Compute the (uncached) digest changes.
+	 *
+	 * @return array[] See {@see Digest::get_changes()} for the shape.
+	 */
+	private function compute_changes(): array {
 		$timeframe = $this->get_timeframe();
 		$modified  = $this->get_updated_posts( $timeframe );
 		$changes   = [];

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -69,6 +69,10 @@ add_action(
 	}
 );
 
+// Invalidate cached digests whenever content that could appear in a digest changes.
+add_action( 'save_post', [ Digest::class, 'flush_cache' ] );
+add_action( 'deleted_post', [ Digest::class, 'flush_cache' ] );
+
 // Enqueue dashboard assets.
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_dashboard_assets' );
 

--- a/tests/Test_Digest_Class.php
+++ b/tests/Test_Digest_Class.php
@@ -280,6 +280,114 @@ class Test_Digest_Class extends TestCase {
 	}
 
 	/**
+	 * The cache key is stable across instances built with the same parameters.
+	 *
+	 * @group cache
+	 */
+	public function test_cache_key_is_stable_for_same_parameters() {
+		$a = new Digest( Digest::PERIOD_WEEK, Digest::GROUP_BY_POST );
+		$b = new Digest( Digest::PERIOD_WEEK, Digest::GROUP_BY_POST );
+		$c = new Digest( Digest::PERIOD_DAY, Digest::GROUP_BY_USER );
+
+		$this->assertSame( $a->get_cache_key(), $b->get_cache_key() );
+		$this->assertNotSame( $a->get_cache_key(), $c->get_cache_key() );
+	}
+
+	/**
+	 * get_changes() writes its result to a transient.
+	 *
+	 * @group cache
+	 */
+	public function test_get_changes_writes_transient_cache() {
+		$digest = new Digest();
+		$this->assertFalse( get_transient( $digest->get_cache_key() ) );
+
+		$digest->get_changes();
+
+		// A miss returns false; an array (even empty) means it was cached.
+		$this->assertIsArray( get_transient( $digest->get_cache_key() ) );
+	}
+
+	/**
+	 * A second call returns the cached payload rather than recomputing.
+	 *
+	 * @group cache
+	 */
+	public function test_get_changes_serves_from_cache() {
+		$digest = new Digest();
+		$digest->get_changes();
+
+		// Poison the cache with a sentinel; a cached read returns it verbatim.
+		set_transient( $digest->get_cache_key(), [ 'sentinel' => true ], HOUR_IN_SECONDS );
+
+		$this->assertSame( [ 'sentinel' => true ], ( new Digest() )->get_changes() );
+	}
+
+	/**
+	 * flush_cache() invalidates previously cached results.
+	 *
+	 * @group cache
+	 */
+	public function test_flush_cache_invalidates_cached_results() {
+		$digest = new Digest();
+		$digest->get_changes();
+		set_transient( $digest->get_cache_key(), [ 'sentinel' => true ], HOUR_IN_SECONDS );
+
+		Digest::flush_cache();
+
+		// After a flush the key changes, so the poisoned entry is no longer read.
+		$this->assertNotSame( [ 'sentinel' => true ], ( new Digest() )->get_changes() );
+	}
+
+	/**
+	 * A cache hit returns real objects (not __PHP_Incomplete_Class), so
+	 * get_grouped_changes() can still read the diff. This is the round-trip
+	 * the stored payload must survive.
+	 *
+	 * @group cache
+	 */
+	public function test_cached_payload_round_trips_real_objects() {
+		$this->create_page_with_revisions(
+			'Original body',
+			'Rewritten body with changes',
+			strtotime( '-10 days' ),
+			strtotime( '-2 days' )
+		);
+
+		// First call computes and caches the full object payload.
+		$first = ( new Digest() )->get_changes();
+		$this->assertNotEmpty( $first );
+
+		// Second call is served from the transient (unserialized objects).
+		$cached = ( new Digest() )->get_changes();
+		$this->assertNotEmpty( $cached );
+
+		$change = $cached[0];
+		$this->assertInstanceOf( \Text_Diff::class, $change['diff'] );
+		$this->assertInstanceOf( \WP_Post::class, $change['latest'] );
+		$this->assertInstanceOf( \WP_Post::class, $change['earliest'] );
+		$this->assertNotInstanceOf( \__PHP_Incomplete_Class::class, $change['diff'] );
+		$this->assertSame( $first[0]['post_id'], $change['post_id'] );
+		$this->assertSame( $first[0]['rendered'], $change['rendered'] );
+	}
+
+	/**
+	 * Caching can be disabled via the TTL filter returning a non-positive value.
+	 *
+	 * @group cache
+	 */
+	public function test_cache_can_be_disabled_via_ttl_filter() {
+		add_filter( 'revisions_digest_cache_ttl', '__return_zero' );
+
+		$digest = new Digest();
+		$digest->get_changes();
+
+		$this->assertFalse( get_transient( $digest->get_cache_key() ) );
+
+		remove_filter( 'revisions_digest_cache_ttl', '__return_zero' );
+	}
+
+	/**
 	 * Text_Diff::getEdits() is not available in all WP test environments.
 	 *
 	 * @group digest


### PR DESCRIPTION
## Summary

Implements caching for digest results (closes #23).

- Caches `Digest::get_changes()` in a transient — default 1 hour, filterable via `revisions_digest_cache_ttl` (return `0` to disable). Key derives from period, grouping, custom timeframe, and the `revisions_digest_post_types` option.
- Invalidates via a **cache-version option** bumped on `save_post`/`deleted_post`, rather than enumerating or running raw `DELETE` on transient rows. This stays correct and atomic behind a persistent object cache (where wildcard transient deletion is unreliable).
- Caches the **full object payload** (including `Text_Diff`/`WP_Post`) and loads the diff classes before reading the transient, so cached objects round-trip intact — `get_grouped_changes()` (used by the dashboard widget and REST controller) benefits from the cache too.

### Why not the previous approach (#28)

The earlier closed attempt stripped non-serializable objects from the payload, forcing `get_grouped_changes()` to bypass the cache entirely (no benefit for the widget/REST), and invalidated via raw SQL `DELETE` on `wp_options`. This version keeps the objects and uses object-cache-safe versioned invalidation.

## Test plan

Added 6 `@group cache` tests in `Test_Digest_Class.php`:
- Cache key stability/uniqueness per parameters
- Transient is written on compute
- Second call served from cache
- `flush_cache()` invalidates
- **Cached payload round-trips real `Text_Diff`/`WP_Post` objects** (the failure mode that sank #28)
- TTL filter can disable caching

Full suite: 52 passing, 1 environment-skipped (pre-existing). PHPCS and PHPStan clean.