### PR TITLE
Make the digest period configurable in the settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Digests can be consumed via:
 * [ ] An RSS feed
 * [ ] A REST API endpoint
 
-The default duration for a digest is weekly. In a future version this will be configurable.
+The default duration for a digest is weekly. This can be changed to daily or monthly under **Settings → Reading → Revisions Digest Period**, which controls the dashboard widget and RSS feed.
 
 ## New Helper Class API
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A WordPress plugin which generates digests of changes to content via their revis
 Digests can be consumed via:
 
 * [x] A dashboard widget
-* [ ] Email
-* [ ] An RSS feed
-* [ ] A REST API endpoint
+* [x] Email
+* [x] An RSS feed
+* [x] A REST API endpoint
 
 The default duration for a digest is weekly. This can be changed to daily or monthly under **Settings → Reading → Revisions Digest Period**, which controls the dashboard widget and RSS feed.
 

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -408,8 +408,22 @@ function render_subscription_list( array $subscriptions, string $nonce ): void {
  * }
  */
 function get_digest_changes(): array {
-	$digest = new Digest();
+	$digest = new Digest( get_configured_period() );
 	return $digest->get_changes();
+}
+
+/**
+ * Get the configured digest period.
+ *
+ * Reads the `revisions_digest_period` option, falling back to a weekly
+ * period when unset or invalid.
+ *
+ * @return string One of the Digest::PERIOD_* constants.
+ */
+function get_configured_period(): string {
+	$period = get_option( 'revisions_digest_period', Digest::PERIOD_WEEK );
+
+	return sanitize_period_setting( $period );
 }
 
 /**
@@ -1211,6 +1225,23 @@ function register_settings(): void {
 			'default'           => [ 'page' ],
 		]
 	);
+	register_setting(
+		'reading',
+		'revisions_digest_period',
+		[
+			'type'              => 'string',
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_period_setting',
+			'default'           => Digest::PERIOD_WEEK,
+		]
+	);
+
+	add_settings_field(
+		'revisions_digest_period',
+		__( 'Revisions Digest Period', 'revisions-digest' ),
+		__NAMESPACE__ . '\render_period_setting',
+		'reading',
+		'default'
+	);
 
 	add_settings_field(
 		'revisions_digest_post_types',
@@ -1240,6 +1271,46 @@ function sanitize_post_types_setting( $value ): array {
 		return [ 'page' ];
 	}
 	return array_map( 'sanitize_key', $value );
+}
+
+/**
+ * Sanitize the digest period setting.
+ *
+ * @param mixed $value The submitted value.
+ * @return string A valid Digest::PERIOD_* constant; defaults to weekly.
+ */
+function sanitize_period_setting( $value ): string {
+	$allowed = [ Digest::PERIOD_DAY, Digest::PERIOD_WEEK, Digest::PERIOD_MONTH ];
+
+	if ( is_string( $value ) && in_array( $value, $allowed, true ) ) {
+		return $value;
+	}
+
+	return Digest::PERIOD_WEEK;
+}
+
+/**
+ * Render the digest period setting dropdown.
+ */
+function render_period_setting(): void {
+	$selected = get_configured_period();
+	$options  = [
+		Digest::PERIOD_DAY   => __( 'Daily', 'revisions-digest' ),
+		Digest::PERIOD_WEEK  => __( 'Weekly', 'revisions-digest' ),
+		Digest::PERIOD_MONTH => __( 'Monthly', 'revisions-digest' ),
+	];
+
+	echo '<select name="revisions_digest_period" id="revisions_digest_period">';
+	foreach ( $options as $value => $label ) {
+		printf(
+			'<option value="%s" %s>%s</option>',
+			esc_attr( $value ),
+			selected( $selected, $value, false ),
+			esc_html( $label )
+		);
+	}
+	echo '</select>';
+	echo '<p class="description">' . esc_html__( 'How far back the dashboard widget and RSS feed look for content changes.', 'revisions-digest' ) . '</p>';
 }
 
 /**

--- a/tests/Test_Settings.php
+++ b/tests/Test_Settings.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace RevisionsDigest\Tests;
+
+use RevisionsDigest\Digest;
+
+/**
+ * @group settings
+ */
+class Test_Settings extends TestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( 'revisions_digest_period' );
+	}
+
+	public function test_configured_period_defaults_to_week() {
+		$this->assertSame( Digest::PERIOD_WEEK, \RevisionsDigest\get_configured_period() );
+	}
+
+	public function test_configured_period_returns_saved_value() {
+		update_option( 'revisions_digest_period', Digest::PERIOD_DAY );
+		$this->assertSame( Digest::PERIOD_DAY, \RevisionsDigest\get_configured_period() );
+
+		update_option( 'revisions_digest_period', Digest::PERIOD_MONTH );
+		$this->assertSame( Digest::PERIOD_MONTH, \RevisionsDigest\get_configured_period() );
+	}
+
+	public function test_configured_period_falls_back_for_invalid_value() {
+		update_option( 'revisions_digest_period', 'fortnight' );
+		$this->assertSame( Digest::PERIOD_WEEK, \RevisionsDigest\get_configured_period() );
+	}
+
+	public function test_sanitize_period_setting_accepts_valid_periods() {
+		$this->assertSame( Digest::PERIOD_DAY, \RevisionsDigest\sanitize_period_setting( 'day' ) );
+		$this->assertSame( Digest::PERIOD_WEEK, \RevisionsDigest\sanitize_period_setting( 'week' ) );
+		$this->assertSame( Digest::PERIOD_MONTH, \RevisionsDigest\sanitize_period_setting( 'month' ) );
+	}
+
+	public function test_sanitize_period_setting_rejects_invalid_value() {
+		$this->assertSame( Digest::PERIOD_WEEK, \RevisionsDigest\sanitize_period_setting( 'year' ) );
+		$this->assertSame( Digest::PERIOD_WEEK, \RevisionsDigest\sanitize_period_setting( '' ) );
+		$this->assertSame( Digest::PERIOD_WEEK, \RevisionsDigest\sanitize_period_setting( [ 'week' ] ) );
+	}
+
+	/**
+	 * The dashboard widget / RSS entry point honours the configured period:
+	 * a day-period digest must not include a change made five days ago that a
+	 * week-period digest would include.
+	 */
+	public function test_get_digest_changes_honours_configured_period() {
+		$five_days_ago = strtotime( '-5 days' );
+
+		$page = self::post_factory( [
+			'post_content'  => 'Original content',
+			'post_modified' => date( 'Y-m-d H:i:s', $five_days_ago ),
+		] );
+		wp_save_post_revision( $page->ID );
+		wp_update_post( [
+			'ID'           => $page->ID,
+			'post_content' => 'Updated content',
+		] );
+		wp_save_post_revision( $page->ID );
+
+		global $wpdb;
+		foreach ( [ $page->ID, ...wp_list_pluck( wp_get_post_revisions( $page->ID ), 'ID' ) ] as $id ) {
+			$wpdb->update(
+				$wpdb->posts,
+				[
+					'post_modified'     => date( 'Y-m-d H:i:s', $five_days_ago ),
+					'post_modified_gmt' => gmdate( 'Y-m-d H:i:s', $five_days_ago ),
+				],
+				[ 'ID' => $id ]
+			);
+			clean_post_cache( $id );
+		}
+
+		update_option( 'revisions_digest_period', Digest::PERIOD_WEEK );
+		Digest::flush_cache();
+		$this->assertNotEmpty( \RevisionsDigest\get_digest_changes(), 'Week period should include a 5-day-old change.' );
+
+		update_option( 'revisions_digest_period', Digest::PERIOD_DAY );
+		Digest::flush_cache();
+		$this->assertEmpty( \RevisionsDigest\get_digest_changes(), 'Day period should exclude a 5-day-old change.' );
+	}
+}

--- a/tests/Test_Settings.php
+++ b/tests/Test_Settings.php
@@ -63,7 +63,8 @@ class Test_Settings extends TestCase {
 		wp_save_post_revision( $page->ID );
 
 		global $wpdb;
-		foreach ( [ $page->ID, ...wp_list_pluck( wp_get_post_revisions( $page->ID ), 'ID' ) ] as $id ) {
+		$ids = array_merge( [ $page->ID ], wp_list_pluck( wp_get_post_revisions( $page->ID ), 'ID' ) );
+		foreach ( $ids as $id ) {
 			$wpdb->update(
 				$wpdb->posts,
 				[


### PR DESCRIPTION
## Summary

Closes #50. The README promised this ("In a future version this will be configurable") and `Digest` already supported day/week/month — only the wiring was missing.

- New `revisions_digest_period` setting under **Settings → Reading**, rendered as a Daily/Weekly/Monthly `<select>`.
- Sanitized via `sanitize_period_setting()` against the `Digest::PERIOD_*` constants; invalid/unset values fall back to weekly.
- `get_digest_changes()` (the shared entry point for the dashboard widget and RSS feed) now uses the configured period via the new `get_configured_period()` helper.
- Email subscription cadence is intentionally untouched — it uses its own timeframe.
- README updated.

## Test plan

New `@group settings` suite (`Test_Settings.php`, 6 tests):
- Default is weekly; saved value returned; invalid value falls back.
- `sanitize_period_setting()` accepts valid periods, rejects invalid/non-string.
- Integration: `get_digest_changes()` includes a 5-day-old change under `week` but excludes it under `day`.

Full suite: 58 passing, 1 environment-skipped (pre-existing). PHPCS + PHPStan clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable digest period setting (daily, weekly, or monthly) accessible via **Settings → Reading → Revisions Digest Period**.

* **Documentation**
  * Updated documentation to reflect weekly as the default digest duration and how to customize it via the new settings option.

* **Tests**
  * Added test coverage for the new settings configuration and digest period functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/revisions-digest/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->