### PR TITLE
Add a watch list for targeted digests

### DIFF
--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -147,6 +147,7 @@ class Digest {
 			'g'  => $this->group_by,
 			't'  => $this->custom_timeframe,
 			'pt' => get_option( 'revisions_digest_post_types', [ 'page' ] ),
+			'w'  => $this->get_watch_config(),
 		];
 
 		return 'revisions_digest_' . md5( (string) wp_json_encode( $parts ) );
@@ -289,7 +290,68 @@ class Digest {
 			]
 		);
 
-		return $modified->posts;
+		$ids   = $modified->posts;
+		$watch = $this->get_watch_config();
+
+		if ( empty( $watch['post_ids'] ) && empty( $watch['term_ids'] ) ) {
+			return $ids;
+		}
+
+		// A watch list is configured: keep only posts that are explicitly
+		// watched or that belong to a watched term.
+		return array_values(
+			array_filter(
+				$ids,
+				function ( $post_id ) use ( $watch ) {
+					if ( in_array( $post_id, $watch['post_ids'], true ) ) {
+						return true;
+					}
+
+					foreach ( $watch['term_ids'] as $term_id ) {
+						$term = get_term( $term_id );
+						if ( ! $term instanceof \WP_Term ) {
+							continue;
+						}
+
+						if ( true === is_object_in_term( $post_id, $term->taxonomy, $term_id ) ) {
+							return true;
+						}
+					}
+
+					return false;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Get the configured watch list.
+	 *
+	 * Returns watched post and term IDs from the `revisions_digest_watch`
+	 * option, run through the `revisions_digest_watch` filter. An empty list
+	 * (the default) means every modified post is included.
+	 *
+	 * @return array{post_ids: int[], term_ids: int[]} Watch configuration.
+	 */
+	private function get_watch_config(): array {
+		$default = [
+			'post_ids' => [],
+			'term_ids' => [],
+		];
+
+		$watch = get_option( 'revisions_digest_watch', $default );
+
+		/**
+		 * Filters the revisions digest watch list.
+		 *
+		 * @param array{post_ids: int[], term_ids: int[]} $watch Watched post and term IDs.
+		 */
+		$watch = apply_filters( 'revisions_digest_watch', is_array( $watch ) ? $watch : $default );
+
+		return [
+			'post_ids' => array_values( array_map( 'intval', (array) ( $watch['post_ids'] ?? [] ) ) ),
+			'term_ids' => array_values( array_map( 'intval', (array) ( $watch['term_ids'] ?? [] ) ) ),
+		];
 	}
 
 	/**

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -1235,10 +1235,31 @@ function register_settings(): void {
 		]
 	);
 
+	register_setting(
+		'reading',
+		'revisions_digest_watch',
+		[
+			'type'              => 'object',
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_watch_setting',
+			'default'           => [
+				'post_ids' => [],
+				'term_ids' => [],
+			],
+		]
+	);
+
 	add_settings_field(
 		'revisions_digest_period',
 		__( 'Revisions Digest Period', 'revisions-digest' ),
 		__NAMESPACE__ . '\render_period_setting',
+		'reading',
+		'default'
+	);
+
+	add_settings_field(
+		'revisions_digest_watch',
+		__( 'Revisions Digest Watch List', 'revisions-digest' ),
+		__NAMESPACE__ . '\render_watch_setting',
 		'reading',
 		'default'
 	);
@@ -1287,6 +1308,70 @@ function sanitize_period_setting( $value ): string {
 	}
 
 	return Digest::PERIOD_WEEK;
+}
+
+/**
+ * Sanitize the watch list setting.
+ *
+ * Accepts comma-separated ID strings (or arrays) for `post_ids` and
+ * `term_ids` and normalizes them to arrays of positive integers.
+ *
+ * @param mixed $value The submitted value.
+ * @return array{post_ids: int[], term_ids: int[]} Sanitized watch list.
+ */
+function sanitize_watch_setting( $value ): array {
+	$clean = [
+		'post_ids' => [],
+		'term_ids' => [],
+	];
+
+	if ( ! is_array( $value ) ) {
+		return $clean;
+	}
+
+	foreach ( [ 'post_ids', 'term_ids' ] as $key ) {
+		$raw = $value[ $key ] ?? [];
+
+		if ( is_string( $raw ) ) {
+			$raw = explode( ',', $raw );
+		}
+
+		if ( ! is_array( $raw ) ) {
+			continue;
+		}
+
+		$ids = array_filter( array_map( 'absint', array_map( 'trim', array_map( 'strval', $raw ) ) ) );
+
+		$clean[ $key ] = array_values( array_unique( $ids ) );
+	}
+
+	return $clean;
+}
+
+/**
+ * Render the watch list setting fields.
+ */
+function render_watch_setting(): void {
+	$watch    = get_option(
+		'revisions_digest_watch',
+		[
+			'post_ids' => [],
+			'term_ids' => [],
+		]
+	);
+	$post_ids = implode( ', ', (array) ( $watch['post_ids'] ?? [] ) );
+	$term_ids = implode( ', ', (array) ( $watch['term_ids'] ?? [] ) );
+	?>
+	<label style="display:block; margin-bottom:6px;">
+		<?php esc_html_e( 'Watched post IDs', 'revisions-digest' ); ?><br />
+		<input type="text" class="regular-text" name="revisions_digest_watch[post_ids]" value="<?php echo esc_attr( $post_ids ); ?>" placeholder="e.g. 12, 34" />
+	</label>
+	<label style="display:block; margin-bottom:6px;">
+		<?php esc_html_e( 'Watched term IDs', 'revisions-digest' ); ?><br />
+		<input type="text" class="regular-text" name="revisions_digest_watch[term_ids]" value="<?php echo esc_attr( $term_ids ); ?>" placeholder="e.g. 7, 8" />
+	</label>
+	<p class="description"><?php esc_html_e( 'Comma-separated IDs. When set, the digest only includes these posts and any post in these terms. Leave both empty to include all changes.', 'revisions-digest' ); ?></p>
+	<?php
 }
 
 /**

--- a/tests/Test_Watch.php
+++ b/tests/Test_Watch.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace RevisionsDigest\Tests;
+
+use RevisionsDigest\Digest;
+
+/**
+ * @group watch
+ */
+class Test_Watch extends TestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( 'revisions_digest_watch' );
+		Digest::flush_cache();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'revisions_digest_watch' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a page modified within the last week with two revisions.
+	 *
+	 * @param string $title Page title.
+	 * @return \WP_Post
+	 */
+	private function modified_page( string $title ): \WP_Post {
+		$two_days_ago = strtotime( '-2 days' );
+		$page         = self::post_factory( [
+			'post_title'    => $title,
+			'post_content'  => 'Original content',
+			'post_modified' => date( 'Y-m-d H:i:s', $two_days_ago ),
+		] );
+		wp_save_post_revision( $page->ID );
+		wp_update_post( [
+			'ID'           => $page->ID,
+			'post_content' => 'Updated content for ' . $title,
+		] );
+		wp_save_post_revision( $page->ID );
+
+		return get_post( $page->ID );
+	}
+
+	public function test_empty_watch_list_includes_all_modified_posts() {
+		$a = $this->modified_page( 'Page A' );
+		$b = $this->modified_page( 'Page B' );
+
+		$ids = wp_list_pluck( ( new Digest() )->get_changes(), 'post_id' );
+
+		$this->assertContains( $a->ID, $ids );
+		$this->assertContains( $b->ID, $ids );
+	}
+
+	public function test_watch_by_post_id_limits_results() {
+		$watched   = $this->modified_page( 'Watched' );
+		$unwatched = $this->modified_page( 'Unwatched' );
+
+		update_option( 'revisions_digest_watch', [ 'post_ids' => [ $watched->ID ], 'term_ids' => [] ] );
+		Digest::flush_cache();
+
+		$ids = wp_list_pluck( ( new Digest() )->get_changes(), 'post_id' );
+
+		$this->assertContains( $watched->ID, $ids );
+		$this->assertNotContains( $unwatched->ID, $ids );
+	}
+
+	public function test_watch_by_term_id_limits_results() {
+		$category = self::factory()->category->create( [ 'name' => 'Docs' ] );
+
+		$in_term     = $this->modified_page( 'In Docs' );
+		$not_in_term = $this->modified_page( 'Not In Docs' );
+		wp_set_object_terms( $in_term->ID, [ $category ], 'category' );
+
+		update_option( 'revisions_digest_watch', [ 'post_ids' => [], 'term_ids' => [ $category ] ] );
+		Digest::flush_cache();
+
+		$ids = wp_list_pluck( ( new Digest() )->get_changes(), 'post_id' );
+
+		$this->assertContains( $in_term->ID, $ids );
+		$this->assertNotContains( $not_in_term->ID, $ids );
+	}
+
+	public function test_watch_filter_overrides_option() {
+		$watched   = $this->modified_page( 'Filter Watched' );
+		$unwatched = $this->modified_page( 'Filter Unwatched' );
+
+		add_filter(
+			'revisions_digest_watch',
+			static function () use ( $watched ) {
+				return [ 'post_ids' => [ $watched->ID ], 'term_ids' => [] ];
+			}
+		);
+		Digest::flush_cache();
+
+		$ids = wp_list_pluck( ( new Digest() )->get_changes(), 'post_id' );
+
+		$this->assertSame( [ $watched->ID ], $ids );
+		$this->assertNotContains( $unwatched->ID, $ids );
+	}
+
+	public function test_cache_key_changes_with_watch_config() {
+		$before = ( new Digest() )->get_cache_key();
+
+		update_option( 'revisions_digest_watch', [ 'post_ids' => [ 42 ], 'term_ids' => [] ] );
+
+		$this->assertNotSame( $before, ( new Digest() )->get_cache_key() );
+	}
+
+	public function test_sanitize_watch_setting_parses_comma_separated_ids() {
+		$result = \RevisionsDigest\sanitize_watch_setting(
+			[
+				'post_ids' => '12, 34, foo, 56',
+				'term_ids' => '7,8',
+			]
+		);
+
+		$this->assertSame( [ 12, 34, 56 ], $result['post_ids'] );
+		$this->assertSame( [ 7, 8 ], $result['term_ids'] );
+	}
+
+	public function test_sanitize_watch_setting_handles_garbage() {
+		$result = \RevisionsDigest\sanitize_watch_setting( 'not-an-array' );
+
+		$this->assertSame( [ 'post_ids' => [], 'term_ids' => [] ], $result );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #51. The README's core use case is following specific content (e.g. the docs pages you maintain); previously the digest was all-or-nothing across the configured post types.

- New `revisions_digest_watch` option shaped `{ post_ids: int[], term_ids: int[] }`, run through a `revisions_digest_watch` filter (the programmatic interface called out in the issue).
- `Digest::get_updated_posts()` applies it: when non-empty, results are limited to watched posts **plus** any post belonging to a watched term. Term membership is resolved via the term's own taxonomy (`is_object_in_term`), so it works even for post types that don't register that taxonomy.
- **Empty watch list = unchanged behaviour** (all changes shown).
- The watch config is folded into `get_cache_key()` so the caching layer (#23) stays correct when the list changes.
- **Settings → Reading** fields for comma-separated post/term IDs; `sanitize_watch_setting()` normalizes strings or arrays to unique positive integers.

### Scope note

This ships a site-wide watch list with a lightweight text-field UI (consistent with the existing post-types/period settings) plus the filter for programmatic/per-context control. A richer post/term picker or per-user lists can build on `revisions_digest_watch` later without breaking this contract.

## Test plan

New `@group watch` suite (`Test_Watch.php`, 7 tests): empty list includes all; watch-by-post-ID limits; watch-by-term-ID limits; filter overrides option; cache key changes with config; sanitizer parses comma-separated IDs and rejects garbage.

Full suite: 65 passing, 1 environment-skipped (pre-existing). PHPCS + PHPStan clean.