### PR TITLE
Add a WP-CLI command to generate and manage digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ The class provides intelligent descriptions for changes:
 - **Backward compatibility**: all existing functions continue to work unchanged
 - **Clean API**: object-oriented interface with sensible defaults
 
+## WP-CLI
+
+When WP-CLI is available the plugin registers a `revisions-digest` command:
+
+```bash
+# List recent changes (defaults: --period=week --group-by=post --format=table)
+wp revisions-digest list
+wp revisions-digest list --period=month --group-by=user --format=json
+
+# Clear all cached digests
+wp revisions-digest flush-cache
+```
+
 ## Minimum Requirements
 
 **PHP:** 7.1  

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
 		"phpstan/phpstan": "^2.0",
 		"phpunit/phpunit": "^9.0",
 		"wp-coding-standards/wpcs": "^3.1",
-		"yoast/phpunit-polyfills": "^2.0"
+		"yoast/phpunit-polyfills": "^2.0",
+		"php-stubs/wp-cli-stubs": "^2.12"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "502a2569c968af88fa4089ebd5c1cfdc",
+    "content-hash": "a68799cbf086670ef851fe810614a832",
     "packages": [
         {
             "name": "composer/installers",
@@ -606,6 +606,50 @@
                 "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
             },
             "time": "2025-12-03T23:06:24+00:00"
+        },
+        {
+            "name": "php-stubs/wp-cli-stubs",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wp-cli-stubs.git",
+                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wp-cli-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress",
+                "wp-cli"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/v2.12.0"
+            },
+            "time": "2025-06-10T09:58:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -2750,15 +2794,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/class-cli-command.php
+++ b/includes/class-cli-command.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * WP-CLI command for the Revisions Digest plugin.
+ *
+ * @package   revisions-digest
+ */
+
+declare( strict_types=1 );
+
+namespace RevisionsDigest;
+
+/**
+ * Generate and manage revisions digests from the command line.
+ */
+class CLI_Command {
+
+	/**
+	 * List recent content changes.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--period=<period>]
+	 * : How far back to look. One of day, week, month.
+	 * ---
+	 * default: week
+	 * options:
+	 *   - day
+	 *   - week
+	 *   - month
+	 * ---
+	 *
+	 * [--group-by=<group_by>]
+	 * : How to group results. One of post, date, user, taxonomy.
+	 * ---
+	 * default: post
+	 * options:
+	 *   - post
+	 *   - date
+	 *   - user
+	 *   - taxonomy
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output as a table, JSON, CSV, YAML, or count.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp revisions-digest list --period=month --format=json
+	 *
+	 * @param string[] $args       Positional arguments (unused).
+	 * @param array    $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function list( array $args, array $assoc_args ): void {
+		$period   = self::normalize_period( (string) ( $assoc_args['period'] ?? Digest::PERIOD_WEEK ) );
+		$group_by = self::normalize_group_by( (string) ( $assoc_args['group-by'] ?? Digest::GROUP_BY_POST ) );
+
+		if ( null === $period ) {
+			\WP_CLI::error( 'Invalid --period. Use day, week, or month.' );
+		}
+		if ( null === $group_by ) {
+			\WP_CLI::error( 'Invalid --group-by. Use post, date, user, or taxonomy.' );
+		}
+
+		$digest = new Digest( $period, $group_by );
+		$rows   = self::to_rows( $digest->get_changes() );
+
+		if ( empty( $rows ) ) {
+			\WP_CLI::success( 'No content changes in the selected period.' );
+			return;
+		}
+
+		\WP_CLI\Utils\format_items(
+			(string) ( $assoc_args['format'] ?? 'table' ),
+			$rows,
+			[ 'post_id', 'title', 'authors', 'modified' ]
+		);
+	}
+
+	/**
+	 * Clear all cached digests.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp revisions-digest flush-cache
+	 *
+	 * @subcommand flush-cache
+	 *
+	 * @param string[] $args       Positional arguments (unused).
+	 * @param array    $assoc_args Associative arguments (unused).
+	 * @return void
+	 */
+	public function flush_cache( array $args, array $assoc_args ): void {
+		Digest::flush_cache();
+		\WP_CLI::success( 'Revisions digest cache cleared.' );
+	}
+
+	/**
+	 * Flatten a (possibly grouped) changes structure into table rows.
+	 *
+	 * @param array $changes Output of Digest::get_changes() or get_grouped_changes().
+	 * @return array<int, array{post_id: int, title: string, authors: int, modified: string}>
+	 */
+	public static function to_rows( array $changes ): array {
+		$rows = [];
+
+		foreach ( self::collect_changes( $changes ) as $change ) {
+			$latest = $change['latest'] ?? null;
+
+			$rows[] = [
+				'post_id'  => (int) ( $change['post_id'] ?? 0 ),
+				'title'    => $latest instanceof \WP_Post ? $latest->post_title : '',
+				'authors'  => count( (array) ( $change['authors'] ?? [] ) ),
+				'modified' => $latest instanceof \WP_Post ? $latest->post_modified : '',
+			];
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Recursively collect individual change entries (arrays with a post_id).
+	 *
+	 * @param array $node A changes array or nested group.
+	 * @return array<int, array> List of change entries.
+	 */
+	private static function collect_changes( array $node ): array {
+		if ( isset( $node['post_id'] ) ) {
+			return [ $node ];
+		}
+
+		$found = [];
+		foreach ( $node as $value ) {
+			if ( is_array( $value ) ) {
+				$found = array_merge( $found, self::collect_changes( $value ) );
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Validate a period string against the Digest constants.
+	 *
+	 * @param string $period Candidate period.
+	 * @return string|null The period, or null if invalid.
+	 */
+	public static function normalize_period( string $period ): ?string {
+		$allowed = [ Digest::PERIOD_DAY, Digest::PERIOD_WEEK, Digest::PERIOD_MONTH ];
+
+		return in_array( $period, $allowed, true ) ? $period : null;
+	}
+
+	/**
+	 * Validate a group-by string against the Digest constants.
+	 *
+	 * @param string $group_by Candidate grouping.
+	 * @return string|null The grouping, or null if invalid.
+	 */
+	public static function normalize_group_by( string $group_by ): ?string {
+		$allowed = [
+			Digest::GROUP_BY_POST,
+			Digest::GROUP_BY_DATE,
+			Digest::GROUP_BY_USER,
+			Digest::GROUP_BY_TAXONOMY,
+		];
+
+		return in_array( $group_by, $allowed, true ) ? $group_by : null;
+	}
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
 		- includes
 	scanFiles:
 		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+		- vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
 	bootstrapFiles:
 		- phpstan-bootstrap.php
 	ignoreErrors:

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -46,6 +46,13 @@ require_once __DIR__ . '/includes/class-digest.php';
 // Include the REST controller class.
 require_once __DIR__ . '/includes/class-rest-controller.php';
 
+// Include and register the WP-CLI command.
+require_once __DIR__ . '/includes/class-cli-command.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	\WP_CLI::add_command( 'revisions-digest', __NAMESPACE__ . '\CLI_Command' );
+}
+
 add_action(
 	'wp_dashboard_setup',
 	function () {

--- a/tests/Test_CLI_Command.php
+++ b/tests/Test_CLI_Command.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace RevisionsDigest\Tests;
+
+use RevisionsDigest\CLI_Command;
+
+/**
+ * @group cli
+ */
+class Test_CLI_Command extends TestCase {
+
+	private function fake_change( int $post_id, string $title, array $authors ): array {
+		$post = self::post_factory( [ 'post_title' => $title ] );
+		// Force a deterministic post_modified for the assertion.
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->posts,
+			[ 'post_modified' => '2026-05-01 10:00:00' ],
+			[ 'ID' => $post->ID ]
+		);
+		clean_post_cache( $post->ID );
+
+		return [
+			'post_id'  => $post_id,
+			'latest'   => get_post( $post->ID ),
+			'earliest' => get_post( $post->ID ),
+			'authors'  => $authors,
+		];
+	}
+
+	public function test_command_class_exists_without_wp_cli() {
+		$this->assertFalse( defined( 'WP_CLI' ) && WP_CLI );
+		$this->assertTrue( class_exists( CLI_Command::class ) );
+	}
+
+	public function test_to_rows_on_flat_changes() {
+		$changes = [
+			$this->fake_change( 11, 'Alpha', [ 1 ] ),
+			$this->fake_change( 22, 'Beta', [ 1, 2 ] ),
+		];
+
+		$rows = CLI_Command::to_rows( $changes );
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( 11, $rows[0]['post_id'] );
+		$this->assertSame( 'Alpha', $rows[0]['title'] );
+		$this->assertSame( 2, $rows[1]['authors'] );
+		$this->assertSame( '2026-05-01 10:00:00', $rows[0]['modified'] );
+	}
+
+	public function test_to_rows_flattens_grouped_structure() {
+		$grouped = [
+			'2026-05-01' => [ $this->fake_change( 11, 'Alpha', [ 1 ] ) ],
+			'2026-05-02' => [
+				$this->fake_change( 22, 'Beta', [ 1 ] ),
+				$this->fake_change( 33, 'Gamma', [ 1 ] ),
+			],
+		];
+
+		$rows = CLI_Command::to_rows( $grouped );
+
+		$this->assertCount( 3, $rows );
+		$this->assertEqualsCanonicalizing(
+			[ 11, 22, 33 ],
+			wp_list_pluck( $rows, 'post_id' )
+		);
+	}
+
+	public function test_to_rows_on_empty() {
+		$this->assertSame( [], CLI_Command::to_rows( [] ) );
+	}
+
+	public function test_normalize_period_validates_against_constants() {
+		$this->assertSame( 'day', CLI_Command::normalize_period( 'day' ) );
+		$this->assertSame( 'week', CLI_Command::normalize_period( 'week' ) );
+		$this->assertSame( 'month', CLI_Command::normalize_period( 'month' ) );
+		$this->assertNull( CLI_Command::normalize_period( 'decade' ) );
+	}
+
+	public function test_normalize_group_by_validates_against_constants() {
+		$this->assertSame( 'post', CLI_Command::normalize_group_by( 'post' ) );
+		$this->assertSame( 'user', CLI_Command::normalize_group_by( 'user' ) );
+		$this->assertNull( CLI_Command::normalize_group_by( 'banana' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #52. Adds a `wp revisions-digest` command for automation (cron static exports, CI changelogs) and quick debugging without wp-admin.

- Registered only when `WP_CLI` is defined.
- `wp revisions-digest list [--period=] [--group-by=] [--format=]` — `--period`/`--group-by` validated against the `Digest::PERIOD_*`/`GROUP_BY_*` constants; output via `WP_CLI\Utils\format_items()` (table/json/csv/yaml/count).
- `wp revisions-digest flush-cache` — calls `Digest::flush_cache()` (cache from #23). Explicit `@subcommand flush-cache` so the hyphenated name matches the issue.
- Logic lives in pure, `WP_CLI`-free static helpers (`to_rows`, `normalize_period`, `normalize_group_by`) so it's unit-testable; `to_rows` flattens both the flat and grouped `get_changes()` shapes.
- Added `php-stubs/wp-cli-stubs` (dev) to PHPStan `scanFiles` — same pattern as the existing `wordpress-stubs`. README documents the command.

## Test plan

New `@group cli` suite (`Test_CLI_Command.php`, 6 tests): class loads without WP_CLI; `to_rows` on flat / grouped / empty; period & group-by validation.

Full suite: 71 passing, 1 environment-skipped (pre-existing). PHPCS + PHPStan clean.

> Note: CodeRabbit may be rate-limited from the recent PR cadence; CI gates (PHPUnit ×4, PHPCS, PHPStan, JS/CSS) are the authoritative checks here.