### PR TITLE
Include newly published and removed content in the digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The class provides intelligent descriptions for changes:
 
 ## Features
 
+- **Full lifecycle**: edits, newly published content, and removed (trashed) content
 - **Multiple time periods**: day, week, month, or custom timeframes
 - **Flexible grouping**: by date, user, post, or taxonomy
 - **Intelligent descriptions**: contextual descriptions of who changed what and when

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -214,6 +214,7 @@ class Digest {
 
 			$data = [
 				'post_id'          => $modified_post_id,
+				'type'             => 'modified',
 				'latest'           => $bounds['latest'],
 				'earliest'         => $bounds['earliest'],
 				'diff'             => $diff,
@@ -226,7 +227,52 @@ class Digest {
 			$changes[] = $data;
 		}
 
+		$seen = wp_list_pluck( $changes, 'post_id' );
+
+		// Posts published in this period that aren't already shown as edits.
+		foreach ( $this->get_added_posts( $timeframe ) as $added_id ) {
+			if ( in_array( $added_id, $seen, true ) ) {
+				continue;
+			}
+			$changes[] = $this->build_simple_change( $added_id, 'added' );
+			$seen[]    = $added_id;
+		}
+
+		// Posts trashed in this period.
+		foreach ( $this->get_removed_posts( $timeframe ) as $removed_id ) {
+			if ( in_array( $removed_id, $seen, true ) ) {
+				continue;
+			}
+			$changes[] = $this->build_simple_change( $removed_id, 'removed' );
+			$seen[]    = $removed_id;
+		}
+
 		return $this->group_changes( $changes );
+	}
+
+	/**
+	 * Build a change entry for an added or removed post.
+	 *
+	 * These carry no diff; consumers key off the `type` field.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $type    Either 'added' or 'removed'.
+	 * @return array A change entry shaped like the modified entries.
+	 */
+	private function build_simple_change( int $post_id, string $type ): array {
+		$post = get_post( $post_id );
+
+		return [
+			'post_id'          => $post_id,
+			'type'             => $type,
+			'latest'           => $post,
+			'earliest'         => null,
+			'diff'             => null,
+			'rendered'         => '',
+			'title_rendered'   => '',
+			'excerpt_rendered' => '',
+			'authors'          => $post instanceof WP_Post ? [ (int) $post->post_author ] : [],
+		];
 	}
 
 	/**
@@ -267,30 +313,90 @@ class Digest {
 	 * @return int[] Array of post IDs.
 	 */
 	private function get_updated_posts( int $timeframe ): array {
-		$earliest = gmdate( 'Y-m-d H:i:s', $timeframe );
-
-		/**
-		 * Filters the post types included in the revisions digest.
-		 *
-		 * @param string[] $post_types Array of post type slugs. Default: array( 'page' ).
-		 */
-		$default_types = get_option( 'revisions_digest_post_types', [ 'page' ] );
-		$post_types    = apply_filters( 'revisions_digest_post_types', $default_types );
-
 		// Fetch IDs of all posts that have been modified within the time period.
 		$modified = new WP_Query(
 			[
 				'fields'      => 'ids',
-				'post_type'   => $post_types,
+				'post_type'   => $this->get_post_types(),
 				'post_status' => 'publish',
 				'date_query'  => [
-					'after'  => $earliest,
+					'after'  => gmdate( 'Y-m-d H:i:s', $timeframe ),
 					'column' => 'post_modified',
 				],
 			]
 		);
 
-		$ids   = $modified->posts;
+		return $this->apply_watch_filter( $modified->posts );
+	}
+
+	/**
+	 * Get posts first published within the timeframe.
+	 *
+	 * @param int $timeframe Only posts published after this timestamp.
+	 * @return int[] Array of post IDs.
+	 */
+	private function get_added_posts( int $timeframe ): array {
+		$added = new WP_Query(
+			[
+				'fields'      => 'ids',
+				'post_type'   => $this->get_post_types(),
+				'post_status' => 'publish',
+				'date_query'  => [
+					'after'  => gmdate( 'Y-m-d H:i:s', $timeframe ),
+					'column' => 'post_date',
+				],
+			]
+		);
+
+		return $this->apply_watch_filter( $added->posts );
+	}
+
+	/**
+	 * Get posts trashed within the timeframe.
+	 *
+	 * @param int $timeframe Only posts trashed after this timestamp.
+	 * @return int[] Array of post IDs.
+	 */
+	private function get_removed_posts( int $timeframe ): array {
+		$removed = new WP_Query(
+			[
+				'fields'      => 'ids',
+				'post_type'   => $this->get_post_types(),
+				'post_status' => 'trash',
+				'date_query'  => [
+					'after'  => gmdate( 'Y-m-d H:i:s', $timeframe ),
+					'column' => 'post_modified',
+				],
+			]
+		);
+
+		return $this->apply_watch_filter( $removed->posts );
+	}
+
+	/**
+	 * Get the post types included in the digest.
+	 *
+	 * @return string[] Array of post type slugs.
+	 */
+	private function get_post_types(): array {
+		/**
+		 * Filters the post types included in the revisions digest.
+		 *
+		 * @param string[] $post_types Array of post type slugs. Default: array( 'page' ).
+		 */
+		return apply_filters(
+			'revisions_digest_post_types',
+			get_option( 'revisions_digest_post_types', [ 'page' ] )
+		);
+	}
+
+	/**
+	 * Apply the configured watch list to a list of post IDs.
+	 *
+	 * @param int[] $ids Candidate post IDs.
+	 * @return int[] The IDs, filtered to the watch list when one is set.
+	 */
+	private function apply_watch_filter( array $ids ): array {
 		$watch = $this->get_watch_config();
 
 		if ( empty( $watch['post_ids'] ) && empty( $watch['term_ids'] ) ) {
@@ -606,8 +712,20 @@ class Digest {
 		}
 
 		$author_list = implode( ' and ', $authors );
-		$time_desc   = $this->get_time_description( $change['latest']->post_modified );
-		$size_desc   = $this->get_change_size_description( $change['diff'] );
+		$latest      = $change['latest'] ?? null;
+		$time_desc   = $latest instanceof WP_Post ? $this->get_time_description( $latest->post_modified ) : '';
+		$type        = $change['type'] ?? 'modified';
+		$title       = $latest instanceof WP_Post ? $latest->post_title : '';
+
+		if ( 'added' === $type ) {
+			return trim( sprintf( '%s added "%s" %s', $author_list, $title, $time_desc ) );
+		}
+
+		if ( 'removed' === $type ) {
+			return trim( sprintf( '%s removed "%s" %s', $author_list, $title, $time_desc ) );
+		}
+
+		$size_desc = $this->get_change_size_description( $change['diff'] );
 
 		return sprintf(
 			'%s made %s %s',

--- a/revisions-digest.php
+++ b/revisions-digest.php
@@ -251,6 +251,13 @@ function render_widget_content( array $changes ): void {
 				esc_html( $changes_by )
 			);
 
+			$change_type = $change['type'] ?? 'modified';
+			if ( 'added' === $change_type ) {
+				echo '<p class="revisions-digest-status">' . esc_html__( 'New content published in this period.', 'revisions-digest' ) . '</p>';
+			} elseif ( 'removed' === $change_type ) {
+				echo '<p class="revisions-digest-status">' . esc_html__( 'Content removed in this period.', 'revisions-digest' ) . '</p>';
+			}
+
 			if ( ! empty( $change['title_rendered'] ) ) {
 				echo '<h4>' . esc_html__( 'Title', 'revisions-digest' ) . '</h4>';
 				echo '<table class="diff">';
@@ -1129,6 +1136,13 @@ function get_email_content( array $changes, string $unsubscribe_url = '' ): stri
 					?>
 				</p>
 
+				<?php $change_type = $change['type'] ?? 'modified'; ?>
+				<?php if ( 'added' === $change_type ) : ?>
+					<p class="status"><?php esc_html_e( 'New content published in this period.', 'revisions-digest' ); ?></p>
+				<?php elseif ( 'removed' === $change_type ) : ?>
+					<p class="status"><?php esc_html_e( 'Content removed in this period.', 'revisions-digest' ); ?></p>
+				<?php endif; ?>
+
 				<?php if ( ! empty( $change['title_rendered'] ) ) : ?>
 					<h3><?php esc_html_e( 'Title', 'revisions-digest' ); ?></h3>
 					<table class="diff">
@@ -1728,14 +1742,21 @@ function render_feed(): void {
 				?>
 		<dc:creator><?php echo esc_html( $author ); ?></dc:creator>
 			<?php endforeach; ?>
-			<?php $rendered = str_replace( ']]>', ']]]]><![CDATA[>', $change['rendered'] ); ?>
+			<?php $change_type = $change['type'] ?? 'modified'; ?>
 		<description><![CDATA[
+			<?php if ( 'added' === $change_type ) : ?>
+				<p><?php esc_html_e( 'New content published in this period.', 'revisions-digest' ); ?></p>
+			<?php elseif ( 'removed' === $change_type ) : ?>
+				<p><?php esc_html_e( 'Content removed in this period.', 'revisions-digest' ); ?></p>
+			<?php else : ?>
+				<?php $rendered = str_replace( ']]>', ']]]]><![CDATA[>', (string) $change['rendered'] ); ?>
 			<table class="diff">
 				<?php
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $rendered contains safe HTML from WP_Text_Diff_Renderer_Table.
 				echo $rendered;
 				?>
 			</table>
+			<?php endif; ?>
 		]]></description>
 	</item>
 	<?php endforeach; ?>

--- a/tests/Test_Digest_Class.php
+++ b/tests/Test_Digest_Class.php
@@ -147,11 +147,15 @@ class Test_Digest_Class extends TestCase {
 		] );
 		wp_save_post_revision( $page->ID );
 
-		// Fix the page post_modified to the desired timestamp.
+		// Fix the page dates: it was created at the old timestamp and last
+		// modified at the new one. post_date matters now that newly published
+		// posts surface as "added" entries.
 		global $wpdb;
 		$wpdb->update(
 			$wpdb->posts,
 			[
+				'post_date'         => date( 'Y-m-d H:i:s', $old_timestamp ),
+				'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $old_timestamp ),
 				'post_modified'     => date( 'Y-m-d H:i:s', $new_timestamp ),
 				'post_modified_gmt' => gmdate( 'Y-m-d H:i:s', $new_timestamp ),
 			],

--- a/tests/Test_Lifecycle.php
+++ b/tests/Test_Lifecycle.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace RevisionsDigest\Tests;
+
+use RevisionsDigest\Digest;
+
+/**
+ * Added / removed content entries.
+ *
+ * @group lifecycle
+ */
+class Test_Lifecycle extends TestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		Digest::flush_cache();
+	}
+
+	private function entry_for( array $changes, int $post_id ): ?array {
+		foreach ( $changes as $change ) {
+			if ( (int) ( $change['post_id'] ?? 0 ) === $post_id ) {
+				return $change;
+			}
+		}
+		return null;
+	}
+
+	public function test_newly_published_post_appears_as_added() {
+		$page = self::post_factory( [
+			'post_title'  => 'Brand New Page',
+			'post_date'   => date( 'Y-m-d H:i:s', strtotime( '-2 days' ) ),
+		] );
+
+		$changes = ( new Digest() )->get_changes();
+		$entry   = $this->entry_for( $changes, $page->ID );
+
+		$this->assertNotNull( $entry, 'Newly published page should be in the digest.' );
+		$this->assertSame( 'added', $entry['type'] );
+	}
+
+	public function test_trashed_post_appears_as_removed() {
+		$page = self::post_factory( [
+			'post_title' => 'Doomed Page',
+			'post_date'  => date( 'Y-m-d H:i:s', strtotime( '-3 weeks' ) ),
+		] );
+		wp_trash_post( $page->ID );
+
+		$changes = ( new Digest() )->get_changes();
+		$entry   = $this->entry_for( $changes, $page->ID );
+
+		$this->assertNotNull( $entry, 'Trashed page should be in the digest.' );
+		$this->assertSame( 'removed', $entry['type'] );
+	}
+
+	public function test_modified_post_keeps_modified_type_and_no_duplicate() {
+		$four_days_ago = strtotime( '-4 days' );
+		$page          = self::post_factory( [
+			'post_content'  => 'Original',
+			'post_date'     => date( 'Y-m-d H:i:s', strtotime( '-2 months' ) ),
+			'post_modified' => date( 'Y-m-d H:i:s', $four_days_ago ),
+		] );
+		wp_save_post_revision( $page->ID );
+		wp_update_post( [ 'ID' => $page->ID, 'post_content' => 'Updated' ] );
+		wp_save_post_revision( $page->ID );
+
+		$changes = ( new Digest() )->get_changes();
+		$ids     = wp_list_pluck( $changes, 'post_id' );
+
+		$this->assertSame( [ $page->ID ], array_values( array_filter( $ids, fn( $id ) => $id === $page->ID ) ) );
+		$this->assertSame( 'modified', $this->entry_for( $changes, $page->ID )['type'] );
+	}
+
+	public function test_grouped_changes_do_not_fatal_for_added_and_removed() {
+		$added = self::post_factory( [
+			'post_title' => 'Fresh',
+			'post_date'  => date( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+		] );
+		$removed = self::post_factory( [
+			'post_title' => 'Gone',
+			'post_date'  => date( 'Y-m-d H:i:s', strtotime( '-2 months' ) ),
+		] );
+		wp_trash_post( $removed->ID );
+
+		$grouped = ( new Digest() )->get_grouped_changes();
+
+		$this->assertNotEmpty( $grouped );
+		foreach ( $grouped as $group ) {
+			$this->assertArrayHasKey( 'description', $group );
+			$this->assertNotEmpty( $group['description'] );
+		}
+	}
+
+	public function test_watch_list_still_applies_to_added_entries() {
+		$watched = self::post_factory( [
+			'post_title' => 'Watched New',
+			'post_date'  => date( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+		] );
+		$other = self::post_factory( [
+			'post_title' => 'Unwatched New',
+			'post_date'  => date( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+		] );
+
+		update_option( 'revisions_digest_watch', [ 'post_ids' => [ $watched->ID ], 'term_ids' => [] ] );
+		Digest::flush_cache();
+
+		$ids = wp_list_pluck( ( new Digest() )->get_changes(), 'post_id' );
+
+		$this->assertContains( $watched->ID, $ids );
+		$this->assertNotContains( $other->ID, $ids );
+
+		delete_option( 'revisions_digest_watch' );
+	}
+}

--- a/tests/Test_Settings.php
+++ b/tests/Test_Settings.php
@@ -63,6 +63,16 @@ class Test_Settings extends TestCase {
 		wp_save_post_revision( $page->ID );
 
 		global $wpdb;
+		// Backdate the page's publish date too so it isn't picked up as a
+		// newly "added" post, isolating the configured-period (modified) path.
+		$wpdb->update(
+			$wpdb->posts,
+			[
+				'post_date'     => date( 'Y-m-d H:i:s', $five_days_ago ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $five_days_ago ),
+			],
+			[ 'ID' => $page->ID ]
+		);
 		$ids = array_merge( [ $page->ID ], wp_list_pluck( wp_get_post_revisions( $page->ID ), 'ID' ) );
 		foreach ( $ids as $id ) {
 			$wpdb->update(


### PR DESCRIPTION
## Summary

Closes #54. `Digest::get_post_revisions()` returns nothing for posts with fewer than two revisions, so brand-new and trashed pages never appeared — a gap for a "track content changes" tool.

- Every change entry now has a **`type`**: `modified` (unchanged), `added` (first published this period), `removed` (trashed this period).
- `compute_changes()` appends added/removed entries after the modified loop, **de-duplicated** against posts already shown as edits.
- Post-type resolution and watch-list filtering are factored into reusable helpers (`get_post_types()`, `apply_watch_filter()`) and applied to the modified, added, and removed queries — so #51's watch list works for added/removed too.
- `generate_single_description()` branches on type (no `getEdits()` on a null diff).
- **Widget, email, and RSS** show a clear "New content published / Content removed" status line instead of an empty diff table.
- Cache invalidation needs no new hook: trashing and publishing both go through `wp_update_post()` → `save_post` (already hooked to `flush_cache`).

### Pre-existing test fixtures adjusted

`Test_Digest_Class::create_page_with_revisions()` and one `Test_Settings` fixture backdated `post_modified` but left `post_date = now`. With added-detection that now (correctly) reads as "added today". Both fixtures now also backdate `post_date` to the post's real creation time, isolating the modified-path assertions. This is a fixture correction, not a behaviour workaround — production posts have aligned `post_date`/publish events.

## Test plan

New `@group lifecycle` suite (`Test_Lifecycle.php`, 5 tests): newly published → `added`; trashed → `removed`; modified keeps `modified` with no duplicate; `get_grouped_changes()` doesn't fatal for added/removed; watch list still applies to added.

Full suite: 84 passing, 1 environment-skipped (pre-existing). PHPCS + PHPStan clean.